### PR TITLE
fix(docker): remove response body from container creation errors

### DIFF
--- a/packages/docker/src/client/container.ts
+++ b/packages/docker/src/client/container.ts
@@ -120,9 +120,7 @@ export async function createContainer(
   }
 
   if (res.status !== 201) {
-    throw new Error(
-      `Failed to create container ${name}: ${res.status} ${JSON.stringify(res.body)}`,
-    );
+    throw new Error(`Failed to create container ${name}: ${res.status}`);
   }
 
   await client.post(`/containers/${res.body.Id}/start`);


### PR DESCRIPTION
Remove `JSON.stringify(res.body)` from the `createContainer` error message to prevent leaking sensitive `Env` values (passwords, API keys) into CI logs. Only `res.status` and the container name are now included.

Closes #26

Generated with [Claude Code](https://claude.ai/code)