### PR TITLE
fix(docker): apply health check interval and timeout from config

### DIFF
--- a/packages/docker/src/client/container.ts
+++ b/packages/docker/src/client/container.ts
@@ -1,3 +1,4 @@
+import { durationToNanos } from "@vyft/runtime";
 import type { DockerClient } from "./index.ts";
 
 interface ContainerInput {
@@ -89,6 +90,12 @@ export function buildContainerConfig(
         `curl -f http://localhost:${input.port}${input.health.path} || exit 1`,
       ],
     };
+    if (input.health.interval !== undefined) {
+      config.Healthcheck.Interval = durationToNanos(input.health.interval);
+    }
+    if (input.health.timeout !== undefined) {
+      config.Healthcheck.Timeout = durationToNanos(input.health.timeout);
+    }
     if (input.health.retries !== undefined) {
       config.Healthcheck.Retries = input.health.retries;
     }


### PR DESCRIPTION
Parse interval and timeout duration strings with `durationToNanos` and set `Interval` and `Timeout` on the `Healthcheck` config object passed to the Docker API.

Closes #31

Generated with [Claude Code](https://claude.ai/code)