### PR TITLE
chore(vyft): remove nats and rabbitmq resources

### DIFF
--- a/packages/vyft/src/services.ts
+++ b/packages/vyft/src/services.ts
@@ -1,25 +1,9 @@
-import { createProvider, defineResource } from "@vyft/provider";
-
-export interface NatsArgs {
-  version?: string;
-  jetstream?: boolean;
-}
-
-export interface RabbitmqArgs {
-  version?: string;
-  vhost?: string;
-}
-
-const natsResource = defineResource<NatsArgs>("nats", {});
-const rabbitmqResource = defineResource<RabbitmqArgs>("rabbitmq", {});
+import { createProvider } from "@vyft/provider";
 
 const services = createProvider({
   name: "services",
   context: () => ({}),
-  resources: {
-    nats: natsResource,
-    rabbitmq: rabbitmqResource,
-  },
+  resources: {},
 });
 
-export const { nats, rabbitmq } = services;
+export const {} = services;

--- a/packages/vyft/src/services.ts
+++ b/packages/vyft/src/services.ts
@@ -1,9 +1,0 @@
-import { createProvider } from "@vyft/provider";
-
-const services = createProvider({
-  name: "services",
-  context: () => ({}),
-  resources: {},
-});
-
-export const {} = services;


### PR DESCRIPTION
Remove NatsArgs, RabbitmqArgs types and their defineResource registrations as they have no handlers and crash the engine when used in config.

Closes #29

Generated with [Claude Code](https://claude.ai/code)