### PR TITLE
fix(vyft): show error message in deploy failure spinner

### DIFF
--- a/packages/vyft/src/commands/deploy.ts
+++ b/packages/vyft/src/commands/deploy.ts
@@ -64,7 +64,8 @@ export default new Command("deploy")
         },
       });
     } catch (err) {
-      s.stop("failed");
+      const message = err instanceof Error ? err.message : String(err);
+      s.stop(`failed: ${message}`);
       throw err;
     } finally {
       await store.dispose();


### PR DESCRIPTION
Include the error message in the spinner stop text when deploy fails, so the error is visible without digging into the stack trace.

Closes #28

Generated with [Claude Code](https://claude.ai/code)