### PR TITLE
fix(engine): unify dependency sorting across action types

### DIFF
--- a/packages/engine/src/plan.test.ts
+++ b/packages/engine/src/plan.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { plan } from "./plan.ts";
+import type { State } from "./types.ts";
+
+function stepsUrns(steps: { urn: string; action: string }[][]): string[][] {
+  return steps.map((step) => step.map((c) => `${c.urn}:${c.action}`).sort());
+}
+
+function before(
+  steps: { urn: string; action: string }[][],
+  a: string,
+  b: string,
+): boolean {
+  const ai = steps.findIndex((s) => s.some((c) => `${c.urn}:${c.action}` === a));
+  const bi = steps.findIndex((s) => s.some((c) => `${c.urn}:${c.action}` === b));
+  return ai !== -1 && bi !== -1 && ai < bi;
+}
+
+describe("plan", () => {
+  it("creates resources with no dependencies in one step", () => {
+    const desired: State = {
+      entries: {
+        a: { urn: "a", input: {} },
+        b: { urn: "b", input: {} },
+      },
+    };
+    const current: State = { entries: {} };
+
+    const steps = plan(desired, current);
+    assert.equal(steps.length, 1);
+    assert.deepEqual(
+      steps[0].map((c) => c.urn).sort(),
+      ["a", "b"],
+    );
+  });
+
+  it("orders creates by dependency", () => {
+    const desired: State = {
+      entries: {
+        a: { urn: "a", input: {} },
+        b: { urn: "b", input: { dep: { urn: "a" } } },
+      },
+    };
+    const current: State = { entries: {} };
+
+    const steps = plan(desired, current);
+    assert.ok(before(steps, "a:create", "b:create"));
+  });
+
+  it("orders deletes so dependents are deleted before dependencies", () => {
+    const current: State = {
+      entries: {
+        a: { urn: "a", input: {} },
+        b: { urn: "b", input: { dep: { urn: "a" } } },
+      },
+    };
+    const desired: State = { entries: {} };
+
+    const steps = plan(desired, current);
+    assert.ok(before(steps, "b:delete", "a:delete"));
+  });
+
+  it("orders update before delete when updated resource depends on deleted resource", () => {
+    // B is being updated and depends on A. A is being deleted.
+    // B's update must happen before A is destroyed.
+    const current: State = {
+      entries: {
+        a: { urn: "a", input: {} },
+        b: { urn: "b", input: { dep: { urn: "a" } } },
+      },
+    };
+    const desired: State = {
+      entries: {
+        // A is absent → deleted
+        b: { urn: "b", input: { dep: { urn: "a" }, extra: 1 } },
+      },
+    };
+
+    const steps = plan(desired, current);
+    assert.ok(
+      before(steps, "b:update", "a:delete"),
+      `Expected b:update before a:delete, got: ${JSON.stringify(stepsUrns(steps))}`,
+    );
+  });
+
+  it("handles mixed creates, updates, and deletes without cross-action dependencies", () => {
+    const current: State = {
+      entries: {
+        old: { urn: "old", input: {} },
+        kept: { urn: "kept", input: {} },
+      },
+    };
+    const desired: State = {
+      entries: {
+        kept: { urn: "kept", input: { changed: true } },
+        newone: { urn: "newone", input: {} },
+      },
+    };
+
+    const steps = plan(desired, current);
+    const allActions = steps.flat().map((c) => `${c.urn}:${c.action}`).sort();
+    assert.deepEqual(allActions, [
+      "kept:update",
+      "newone:create",
+      "old:delete",
+    ]);
+  });
+
+  it("throws on circular dependencies", () => {
+    const desired: State = {
+      entries: {
+        a: { urn: "a", input: { dep: { urn: "b" } } },
+        b: { urn: "b", input: { dep: { urn: "a" } } },
+      },
+    };
+    const current: State = { entries: {} };
+
+    assert.throws(
+      () => plan(desired, current),
+      /circular/i,
+    );
+  });
+});

--- a/packages/engine/src/plan.test.ts
+++ b/packages/engine/src/plan.test.ts
@@ -12,8 +12,12 @@ function before(
   a: string,
   b: string,
 ): boolean {
-  const ai = steps.findIndex((s) => s.some((c) => `${c.urn}:${c.action}` === a));
-  const bi = steps.findIndex((s) => s.some((c) => `${c.urn}:${c.action}` === b));
+  const ai = steps.findIndex((s) =>
+    s.some((c) => `${c.urn}:${c.action}` === a),
+  );
+  const bi = steps.findIndex((s) =>
+    s.some((c) => `${c.urn}:${c.action}` === b),
+  );
   return ai !== -1 && bi !== -1 && ai < bi;
 }
 
@@ -29,10 +33,7 @@ describe("plan", () => {
 
     const steps = plan(desired, current);
     assert.equal(steps.length, 1);
-    assert.deepEqual(
-      steps[0].map((c) => c.urn).sort(),
-      ["a", "b"],
-    );
+    assert.deepEqual(steps[0]?.map((c) => c.urn).sort(), ["a", "b"]);
   });
 
   it("orders creates by dependency", () => {
@@ -99,7 +100,10 @@ describe("plan", () => {
     };
 
     const steps = plan(desired, current);
-    const allActions = steps.flat().map((c) => `${c.urn}:${c.action}`).sort();
+    const allActions = steps
+      .flat()
+      .map((c) => `${c.urn}:${c.action}`)
+      .sort();
     assert.deepEqual(allActions, [
       "kept:update",
       "newone:create",
@@ -116,9 +120,6 @@ describe("plan", () => {
     };
     const current: State = { entries: {} };
 
-    assert.throws(
-      () => plan(desired, current),
-      /circular/i,
-    );
+    assert.throws(() => plan(desired, current), /circular/i);
   });
 });

--- a/packages/engine/src/plan.ts
+++ b/packages/engine/src/plan.ts
@@ -109,32 +109,44 @@ export function plan(desired: State, current: State): Change[][] {
     ...Object.keys(current.entries),
   ]);
 
-  const forwardDeps = new Map<string, Set<string>>();
-  for (const change of [...creates, ...updates]) {
-    const entry = desired.entries[change.urn];
-    if (entry) {
-      forwardDeps.set(change.urn, collectDeps(change.urn, entry, allUrns));
-    }
-  }
+  const allChanges = [...creates, ...updates, ...deletes];
+  const actionOf = new Map<string, Change["action"]>();
+  for (const c of allChanges) actionOf.set(c.urn, c.action);
 
-  const reverseDeps = new Map<string, Set<string>>();
-  for (const change of deletes) {
-    const entry = current.entries[change.urn];
+  const deps = new Map<string, Set<string>>();
+  for (const c of allChanges) deps.set(c.urn, new Set());
+
+  for (const change of allChanges) {
+    const entry =
+      change.action === "delete"
+        ? current.entries[change.urn]
+        : desired.entries[change.urn];
     if (!entry) continue;
-    const deps = collectDeps(change.urn, entry, allUrns);
-    for (const dep of deps) {
-      const set = reverseDeps.get(dep) ?? new Set<string>();
-      set.add(change.urn);
-      reverseDeps.set(dep, set);
+
+    const rawDeps = collectDeps(change.urn, entry, allUrns);
+
+    for (const dep of rawDeps) {
+      const depAction = actionOf.get(dep);
+      if (!depAction) continue;
+
+      if (change.action !== "delete") {
+        if (depAction !== "delete") {
+          // create/update depends on create/update: dep must come first
+          deps.get(change.urn)!.add(dep);
+        } else {
+          // create/update depends on a resource being deleted:
+          // the deletion must happen after this update
+          deps.get(dep)!.add(change.urn);
+        }
+      } else {
+        if (depAction === "delete") {
+          // delete depends on delete: dependent must be deleted before dependency
+          deps.get(dep)!.add(change.urn);
+        }
+        // delete depending on create/update: no ordering constraint needed
+      }
     }
   }
 
-  for (const change of deletes) {
-    if (!reverseDeps.has(change.urn)) reverseDeps.set(change.urn, new Set());
-  }
-
-  const deleteSteps = topoSort(deletes, reverseDeps);
-  const createUpdateSteps = topoSort([...creates, ...updates], forwardDeps);
-
-  return [...deleteSteps, ...createUpdateSteps];
+  return topoSort(allChanges, deps);
 }

--- a/packages/engine/src/plan.ts
+++ b/packages/engine/src/plan.ts
@@ -132,16 +132,16 @@ export function plan(desired: State, current: State): Change[][] {
       if (change.action !== "delete") {
         if (depAction !== "delete") {
           // create/update depends on create/update: dep must come first
-          deps.get(change.urn)!.add(dep);
+          deps.get(change.urn)?.add(dep);
         } else {
           // create/update depends on a resource being deleted:
           // the deletion must happen after this update
-          deps.get(dep)!.add(change.urn);
+          deps.get(dep)?.add(change.urn);
         }
       } else {
         if (depAction === "delete") {
           // delete depends on delete: dependent must be deleted before dependency
-          deps.get(dep)!.add(change.urn);
+          deps.get(dep)?.add(change.urn);
         }
         // delete depending on create/update: no ordering constraint needed
       }


### PR DESCRIPTION
Build one dependency graph for all changes instead of sorting creates/updates and deletes separately. Reverse edges for deletions so dependents are deleted before their dependencies. Add cross-action edges so updates referencing a resource being deleted run before that deletion occurs.

Closes #25

Generated with [Claude Code](https://claude.ai/code)