### PR TITLE
fix(core): reconcile pending store entries before planning

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,6 +28,7 @@ export {
 export { plan } from "./plan.ts";
 export type { PlatformResourceName } from "./platform.ts";
 export type { Provider, ProviderConfig } from "./provider.ts";
+export { reconcile } from "./reconcile.ts";
 export { refresh } from "./refresh.ts";
 export { type ResolvedResult, resolve } from "./resolve.ts";
 export {

--- a/packages/core/src/reconcile.test.ts
+++ b/packages/core/src/reconcile.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { MemoryBackend, Store } from "@vyft/store";
+import type { Context } from "./context.ts";
+import { reconcile } from "./reconcile.ts";
+import { RESOURCE } from "./resource.ts";
+import type { ResourceDefinition } from "./resource.ts";
+import type { Cipher } from "./secret.ts";
+
+const TEST_URN = "urn:vyft:resource:test:thing:my_thing";
+
+function makeCipher(): Cipher {
+  return {
+    encrypt: async (v: string) => ({ kind: "secret" as const, cipher: v }),
+    decrypt: async (v: unknown) => (v as { cipher: string }).cipher,
+  } as unknown as Cipher;
+}
+
+function makeResource(
+  handlers: ResourceDefinition["handlers"],
+): ResourceDefinition {
+  return { [RESOURCE]: true as const, name: "thing", handlers };
+}
+
+async function makeCtx(
+  store: Store,
+  handlers: ResourceDefinition["handlers"],
+): Promise<Context> {
+  return {
+    store,
+    cipher: makeCipher(),
+    providers: {
+      test: {
+        config: {
+          context: async () => ({}),
+          resources: { thing: makeResource(handlers) },
+        },
+      },
+    } as unknown as Context["providers"],
+    createArtifacts: () => ({
+      write: async () => ({ key: "k" }),
+      read: async () => Buffer.from(""),
+      exists: async () => false,
+      delete: async () => {},
+    }),
+  };
+}
+
+async function seedPending(store: Store): Promise<void> {
+  await store.append({
+    type: "set",
+    key: TEST_URN,
+    data: {
+      status: "pending",
+      urn: TEST_URN,
+      action: "create",
+      input: { name: "my_thing" },
+    },
+  });
+}
+
+describe("reconcile", () => {
+  it("promotes pending entry to committed when read succeeds", async () => {
+    const store = await Store.open(new MemoryBackend());
+    await seedPending(store);
+
+    const ctx = await makeCtx(store, {
+      read: async () => ({ id: "abc", active: true }),
+    });
+
+    await reconcile(ctx);
+
+    assert.equal(store.has(TEST_URN), true);
+    const data = store.get(TEST_URN) as Record<string, unknown>;
+    assert.equal(data["status"], "committed");
+    assert.deepEqual(data["output"], { id: "abc", active: true });
+  });
+
+  it("removes pending entry when read throws", async () => {
+    const store = await Store.open(new MemoryBackend());
+    await seedPending(store);
+
+    const ctx = await makeCtx(store, {
+      read: async () => {
+        throw new Error("not found");
+      },
+    });
+
+    await reconcile(ctx);
+
+    assert.equal(store.has(TEST_URN), false);
+  });
+
+  it("removes pending entry when no read handler exists (ephemeral resource)", async () => {
+    const store = await Store.open(new MemoryBackend());
+    await seedPending(store);
+
+    const ctx = await makeCtx(store, {
+      create: async () => ({ output: {} }),
+    });
+
+    await reconcile(ctx);
+
+    assert.equal(store.has(TEST_URN), false);
+  });
+
+  it("removes pending entry for unknown provider", async () => {
+    const store = await Store.open(new MemoryBackend());
+    await store.append({
+      type: "set",
+      key: "urn:vyft:resource:unknown:thing:x",
+      data: { status: "pending", urn: "urn:vyft:resource:unknown:thing:x", action: "create", input: {} },
+    });
+
+    const ctx = await makeCtx(store, {});
+
+    await reconcile(ctx);
+
+    assert.equal(store.has("urn:vyft:resource:unknown:thing:x"), false);
+  });
+
+  it("does not touch already-committed entries", async () => {
+    const store = await Store.open(new MemoryBackend());
+    await store.append({
+      type: "set",
+      key: TEST_URN,
+      data: {
+        status: "committed",
+        urn: TEST_URN,
+        action: "create",
+        input: { name: "my_thing" },
+        output: { id: "existing" },
+      },
+    });
+
+    let readCalled = false;
+    const ctx = await makeCtx(store, {
+      read: async () => {
+        readCalled = true;
+        return { id: "new" };
+      },
+    });
+
+    await reconcile(ctx);
+
+    assert.equal(readCalled, false);
+    const data = store.get(TEST_URN) as Record<string, unknown>;
+    assert.deepEqual((data["output"] as Record<string, unknown>)["id"], "existing");
+  });
+});

--- a/packages/core/src/reconcile.test.ts
+++ b/packages/core/src/reconcile.test.ts
@@ -3,8 +3,8 @@ import { describe, it } from "node:test";
 import { MemoryBackend, Store } from "@vyft/store";
 import type { Context } from "./context.ts";
 import { reconcile } from "./reconcile.ts";
-import { RESOURCE } from "./resource.ts";
 import type { ResourceDefinition } from "./resource.ts";
+import { RESOURCE } from "./resource.ts";
 import type { Cipher } from "./secret.ts";
 
 const TEST_URN = "urn:vyft:resource:test:thing:my_thing";
@@ -109,7 +109,12 @@ describe("reconcile", () => {
     await store.append({
       type: "set",
       key: "urn:vyft:resource:unknown:thing:x",
-      data: { status: "pending", urn: "urn:vyft:resource:unknown:thing:x", action: "create", input: {} },
+      data: {
+        status: "pending",
+        urn: "urn:vyft:resource:unknown:thing:x",
+        action: "create",
+        input: {},
+      },
     });
 
     const ctx = await makeCtx(store, {});
@@ -145,6 +150,9 @@ describe("reconcile", () => {
 
     assert.equal(readCalled, false);
     const data = store.get(TEST_URN) as Record<string, unknown>;
-    assert.deepEqual((data["output"] as Record<string, unknown>)["id"], "existing");
+    assert.deepEqual(
+      (data["output"] as Record<string, unknown>)["id"],
+      "existing",
+    );
   });
 });

--- a/packages/core/src/reconcile.ts
+++ b/packages/core/src/reconcile.ts
@@ -1,0 +1,80 @@
+import type { Context } from "./context.ts";
+import { sealOutput } from "./envelope.ts";
+import type { ResourceDefinition } from "./resource.ts";
+import { urn } from "./urn.ts";
+
+/**
+ * Reconciles pending store entries before planning.
+ *
+ * `dispatch()` writes `status:"pending"` before calling the provider, then
+ * overwrites with `status:"committed"` on success. If the process is
+ * interrupted between those two writes the WAL is replayed on the next
+ * `Store.open()` and the entry is left pending. `buildCurrentState()` skips
+ * pending entries, so the planner would issue a fresh "create" — potentially
+ * double-creating a resource the provider already made.
+ *
+ * This function resolves every pending entry so that none remain after it
+ * returns:
+ *
+ *   - read handler succeeds   → promote to "committed" with live output
+ *   - read handler throws     → resource absent, remove entry (planner recreates)
+ *   - no read handler         → ephemeral resource (one-shot job, exec, file
+ *                               snapshot); remove entry so the planner can
+ *                               re-issue create on the next run
+ *   - unknown provider/resource → remove entry
+ */
+export async function reconcile(ctx: Context): Promise<void> {
+  for (const [key, value] of ctx.store.entries()) {
+    const data = value as Record<string, unknown>;
+    if (data["status"] !== "pending") continue;
+
+    const parsed = urn.parse(key);
+    const provider = ctx.providers[parsed.provider];
+
+    if (!provider) {
+      await ctx.store.append({ type: "remove", key });
+      continue;
+    }
+
+    const platformResources = provider.config.platform as
+      | Record<string, ResourceDefinition>
+      | undefined;
+    const resource =
+      platformResources?.[parsed.resource] ??
+      provider.config.resources?.[parsed.resource];
+
+    if (!resource) {
+      await ctx.store.append({ type: "remove", key });
+      continue;
+    }
+
+    const readFn = resource.handlers.read;
+    if (!readFn) {
+      // Ephemeral resources have no stable state to query. Remove so the
+      // planner can re-issue create on the next run.
+      await ctx.store.append({ type: "remove", key });
+      continue;
+    }
+
+    const input = data["input"] as Record<string, unknown> | undefined;
+    const providerCtx = await provider.config.context();
+    const artifacts = ctx.createArtifacts(key);
+
+    try {
+      const output = await readFn({
+        input,
+        ctx: Object.assign({}, providerCtx, { artifacts }),
+      });
+      const sealed = await sealOutput(output, ctx.cipher);
+      await ctx.store.append({
+        type: "set",
+        key,
+        data: { ...data, status: "committed", output: sealed },
+      });
+    } catch {
+      // Resource does not exist (or could not be verified). Remove so the
+      // planner issues a fresh create on the next run.
+      await ctx.store.append({ type: "remove", key });
+    }
+  }
+}

--- a/packages/docker/src/resource/cronjob.ts
+++ b/packages/docker/src/resource/cronjob.ts
@@ -8,6 +8,7 @@ import {
   removeContainer,
 } from "../client/container.ts";
 import { pullImage } from "../client/image.ts";
+import { inspectContainer } from "../client/inspect.ts";
 import { ensureNetwork } from "../client/network.ts";
 import type { DockerContext } from "../context.ts";
 
@@ -51,6 +52,13 @@ export const cronjobHandlers: Handlers<CronJobInput, DockerContext> = {
         containerId,
       },
     };
+  },
+
+  async read({ input, ctx }) {
+    const name = containerName(ctx.project, ctx.stage, input.name);
+    const inspect = await inspectContainer(ctx.client, name);
+    if (!inspect) return {};
+    return { name, containerId: inspect.Id };
   },
 
   async update({ input, ctx }) {

--- a/packages/vyft/src/commands/deploy.ts
+++ b/packages/vyft/src/commands/deploy.ts
@@ -1,5 +1,5 @@
 import { spinner } from "@clack/prompts";
-import { type ApplyEvent, apply, toState } from "@vyft/core";
+import { type ApplyEvent, apply, reconcile, toState } from "@vyft/core";
 import { PLATFORM_PROVIDER_NAME } from "@vyft/platform";
 import { RUNTIME_PROVIDER_NAME } from "@vyft/runtime";
 import { Command } from "commander";
@@ -48,6 +48,7 @@ export default new Command("deploy")
     const passphrase = await resolvePassphrase();
     const cipher = createCipher(passphrase, salt);
     const ctx = buildContext(store, cipher, providers, stateDir);
+    await reconcile(ctx);
     const current = buildCurrentState(store);
     const desired = toState(entries);
 

--- a/packages/vyft/src/commands/destroy.ts
+++ b/packages/vyft/src/commands/destroy.ts
@@ -1,5 +1,5 @@
 import { confirm, isCancel, spinner } from "@clack/prompts";
-import { type ApplyEvent, destroy } from "@vyft/core";
+import { type ApplyEvent, destroy, reconcile } from "@vyft/core";
 import { PLATFORM_PROVIDER_NAME } from "@vyft/platform";
 import { RUNTIME_PROVIDER_NAME } from "@vyft/runtime";
 import { Command } from "commander";
@@ -49,6 +49,7 @@ export default new Command("destroy")
     const passphrase = await resolvePassphrase();
     const cipher = createCipher(passphrase, salt);
     const ctx = buildContext(store, cipher, providers, stateDir);
+    await reconcile(ctx);
     const current = buildCurrentState(store);
     const count = Object.keys(current.entries).length;
 

--- a/packages/vyft/src/commands/diff.ts
+++ b/packages/vyft/src/commands/diff.ts
@@ -1,4 +1,4 @@
-import { plan, toState } from "@vyft/core";
+import { plan, reconcile, toState } from "@vyft/core";
 import { PLATFORM_PROVIDER_NAME } from "@vyft/platform";
 import { RUNTIME_PROVIDER_NAME } from "@vyft/runtime";
 import { Command } from "commander";
@@ -47,6 +47,7 @@ export default new Command("diff")
     const passphrase = await resolvePassphrase();
     const cipher = createCipher(passphrase, salt);
     const ctx = buildContext(store, cipher, providers, stateDir);
+    await reconcile(ctx);
     const current = buildCurrentState(store);
     const desired = toState(entries);
 

--- a/packages/vyft/src/commands/refresh.ts
+++ b/packages/vyft/src/commands/refresh.ts
@@ -1,4 +1,4 @@
-import { refresh } from "@vyft/core";
+import { reconcile, refresh } from "@vyft/core";
 import { PLATFORM_PROVIDER_NAME } from "@vyft/platform";
 import { RUNTIME_PROVIDER_NAME } from "@vyft/runtime";
 import { Command } from "commander";
@@ -47,6 +47,7 @@ export default new Command("refresh")
     const passphrase = await resolvePassphrase();
     const cipher = createCipher(passphrase, salt);
     const ctx = buildContext(store, cipher, providers, stateDir);
+    await reconcile(ctx);
     const current = buildCurrentState(store);
 
     try {


### PR DESCRIPTION
Adds a `reconcile()` function that resolves every pending store entry before planning, ensuring no entries are ever left in a pending state.

Ephemeral resources (one-shot job, exec, file) intentionally have no `read` handler; their pending entries are removed so the planner can re-issue create on the next run. Also adds a `read` handler to `docker/cronjob` which was missing but is a fully inspectable long-running container.

Closes #23

Generated with [Claude Code](https://claude.ai/code)