### PR TITLE
feat(vyft): passphrase persistence at ~/.config/vyft/<project>/passphrase

### DIFF
--- a/packages/vyft/src/commands/deploy.ts
+++ b/packages/vyft/src/commands/deploy.ts
@@ -45,7 +45,7 @@ export default new Command("deploy")
 
     const store = await openStore(stateDir);
     const salt = await loadSalt(stateDir);
-    const passphrase = await resolvePassphrase();
+    const passphrase = await resolvePassphrase(project, "deploy");
     const cipher = createCipher(passphrase, salt);
     const ctx = buildContext(store, cipher, providers, stateDir);
     await reconcile(ctx);

--- a/packages/vyft/src/commands/destroy.ts
+++ b/packages/vyft/src/commands/destroy.ts
@@ -46,7 +46,7 @@ export default new Command("destroy")
 
     const store = await openStore(stateDir);
     const salt = await loadSalt(stateDir);
-    const passphrase = await resolvePassphrase();
+    const passphrase = await resolvePassphrase(project, "deploy");
     const cipher = createCipher(passphrase, salt);
     const ctx = buildContext(store, cipher, providers, stateDir);
     await reconcile(ctx);

--- a/packages/vyft/src/commands/diff.ts
+++ b/packages/vyft/src/commands/diff.ts
@@ -44,7 +44,7 @@ export default new Command("diff")
 
     const store = await openStore(stateDir);
     const salt = await loadSalt(stateDir);
-    const passphrase = await resolvePassphrase();
+    const passphrase = await resolvePassphrase(project, "deploy");
     const cipher = createCipher(passphrase, salt);
     const ctx = buildContext(store, cipher, providers, stateDir);
     await reconcile(ctx);

--- a/packages/vyft/src/commands/diff.ts
+++ b/packages/vyft/src/commands/diff.ts
@@ -44,7 +44,7 @@ export default new Command("diff")
 
     const store = await openStore(stateDir);
     const salt = await loadSalt(stateDir);
-    const passphrase = await resolvePassphrase(project, "deploy");
+    const passphrase = await resolvePassphrase(project, "read");
     const cipher = createCipher(passphrase, salt);
     const ctx = buildContext(store, cipher, providers, stateDir);
     await reconcile(ctx);

--- a/packages/vyft/src/commands/local/dev.ts
+++ b/packages/vyft/src/commands/local/dev.ts
@@ -47,7 +47,7 @@ async function deployOnce(cwd: string, project: string, stage: string) {
 
   const store = await openStore(stateDir);
   const salt = await loadSalt(stateDir);
-  const passphrase = await resolvePassphrase();
+  const passphrase = await resolvePassphrase(project, "local");
   const cipher = createCipher(passphrase, salt);
   const ctx = buildContext(store, cipher, providers, stateDir);
   const current = buildCurrentState(store);

--- a/packages/vyft/src/commands/refresh.ts
+++ b/packages/vyft/src/commands/refresh.ts
@@ -44,7 +44,7 @@ export default new Command("refresh")
 
     const store = await openStore(stateDir);
     const salt = await loadSalt(stateDir);
-    const passphrase = await resolvePassphrase();
+    const passphrase = await resolvePassphrase(project, "deploy");
     const cipher = createCipher(passphrase, salt);
     const ctx = buildContext(store, cipher, providers, stateDir);
     await reconcile(ctx);

--- a/packages/vyft/src/commands/refresh.ts
+++ b/packages/vyft/src/commands/refresh.ts
@@ -44,7 +44,7 @@ export default new Command("refresh")
 
     const store = await openStore(stateDir);
     const salt = await loadSalt(stateDir);
-    const passphrase = await resolvePassphrase(project, "deploy");
+    const passphrase = await resolvePassphrase(project, "read");
     const cipher = createCipher(passphrase, salt);
     const ctx = buildContext(store, cipher, providers, stateDir);
     await reconcile(ctx);

--- a/packages/vyft/src/runtime.test.ts
+++ b/packages/vyft/src/runtime.test.ts
@@ -11,7 +11,9 @@ function configPath(project: string): string {
 
 async function cleanupProject(project: string): Promise<void> {
   try {
-    await fs.rm(path.join(os.homedir(), ".config", "vyft", project), { recursive: true });
+    await fs.rm(path.join(os.homedir(), ".config", "vyft", project), {
+      recursive: true,
+    });
   } catch {
     // ignore
   }

--- a/packages/vyft/src/runtime.test.ts
+++ b/packages/vyft/src/runtime.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { resolvePassphrase } from "./runtime.ts";
+
+function configPath(project: string): string {
+  return path.join(os.homedir(), ".config", "vyft", project, "passphrase");
+}
+
+async function cleanupProject(project: string): Promise<void> {
+  try {
+    await fs.rm(path.join(os.homedir(), ".config", "vyft", project), { recursive: true });
+  } catch {
+    // ignore
+  }
+}
+
+describe("resolvePassphrase", () => {
+  const savedEnv = process.env["VYFT_PASSPHRASE"];
+
+  afterEach(() => {
+    if (savedEnv === undefined) {
+      delete process.env["VYFT_PASSPHRASE"];
+    } else {
+      process.env["VYFT_PASSPHRASE"] = savedEnv;
+    }
+  });
+
+  it("returns VYFT_PASSPHRASE env var when set", async () => {
+    process.env["VYFT_PASSPHRASE"] = "env-secret";
+    const result = await resolvePassphrase("any-project", "deploy");
+    assert.equal(result, "env-secret");
+  });
+
+  it("returns persisted passphrase when file exists (deploy mode)", async () => {
+    delete process.env["VYFT_PASSPHRASE"];
+    const project = `test-${Date.now()}`;
+    const filePath = configPath(project);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "stored-secret", { mode: 0o600 });
+    try {
+      const result = await resolvePassphrase(project, "deploy");
+      assert.equal(result, "stored-secret");
+    } finally {
+      await cleanupProject(project);
+    }
+  });
+
+  it("trims trailing newlines from persisted passphrase file", async () => {
+    delete process.env["VYFT_PASSPHRASE"];
+    const project = `test-trim-${Date.now()}`;
+    const filePath = configPath(project);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "my-passphrase\n", { mode: 0o600 });
+    try {
+      const result = await resolvePassphrase(project, "deploy");
+      assert.equal(result, "my-passphrase");
+    } finally {
+      await cleanupProject(project);
+    }
+  });
+
+  it("treats whitespace-only passphrase file as absent", async () => {
+    delete process.env["VYFT_PASSPHRASE"];
+    const project = `test-whitespace-${Date.now()}`;
+    const filePath = configPath(project);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "   \n", { mode: 0o600 });
+    try {
+      // local mode: should generate a new passphrase since file content is empty after trim
+      const result = await resolvePassphrase(project, "local");
+      assert.ok(result.length > 0);
+      assert.notEqual(result.trim(), "");
+    } finally {
+      await cleanupProject(project);
+    }
+  });
+
+  it("generates and persists a passphrase in local mode", async () => {
+    delete process.env["VYFT_PASSPHRASE"];
+    const project = `test-local-${Date.now()}`;
+    try {
+      const result = await resolvePassphrase(project, "local");
+      assert.ok(result.length > 0);
+      const saved = await fs.readFile(configPath(project), "utf8");
+      assert.equal(saved, result);
+    } finally {
+      await cleanupProject(project);
+    }
+  });
+
+  it("returns same generated passphrase on subsequent local calls", async () => {
+    delete process.env["VYFT_PASSPHRASE"];
+    const project = `test-idempotent-${Date.now()}`;
+    try {
+      const first = await resolvePassphrase(project, "local");
+      const second = await resolvePassphrase(project, "local");
+      assert.equal(first, second);
+    } finally {
+      await cleanupProject(project);
+    }
+  });
+
+  it("env var takes precedence over persisted passphrase", async () => {
+    const project = `test-priority-${Date.now()}`;
+    const filePath = configPath(project);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "file-secret", { mode: 0o600 });
+    process.env["VYFT_PASSPHRASE"] = "env-wins";
+    try {
+      const result = await resolvePassphrase(project, "deploy");
+      assert.equal(result, "env-wins");
+    } finally {
+      await cleanupProject(project);
+    }
+  });
+});

--- a/packages/vyft/src/runtime.ts
+++ b/packages/vyft/src/runtime.ts
@@ -28,7 +28,9 @@ function passphraseConfigPath(project: string): string {
   return path.join(os.homedir(), ".config", "vyft", project, "passphrase");
 }
 
-async function readPersistedPassphrase(project: string): Promise<string | null> {
+async function readPersistedPassphrase(
+  project: string,
+): Promise<string | null> {
   try {
     const data = await fs.readFile(passphraseConfigPath(project), "utf8");
     // trim() strips trailing newlines from manually-edited files; whitespace-only content is treated as absent

--- a/packages/vyft/src/runtime.ts
+++ b/packages/vyft/src/runtime.ts
@@ -1,6 +1,8 @@
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
-import { isCancel, password } from "@clack/prompts";
+import { confirm, isCancel, log, password } from "@clack/prompts";
 import { Cipher, type Context, generateSalt, type Provider } from "@vyft/core";
 import type { State } from "@vyft/engine";
 import { LocalBackend, Store } from "@vyft/store";
@@ -22,13 +24,52 @@ export function resolveStateDir(
   return path.join(cwd, VYFT_DIR, context, project, stage);
 }
 
-export async function resolvePassphrase(): Promise<string> {
+function passphraseConfigPath(project: string): string {
+  return path.join(os.homedir(), ".config", "vyft", project, "passphrase");
+}
+
+async function readPersistedPassphrase(project: string): Promise<string | null> {
+  try {
+    const data = await fs.readFile(passphraseConfigPath(project), "utf8");
+    return data.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+async function persistPassphrase(project: string, passphrase: string): Promise<void> {
+  const filePath = passphraseConfigPath(project);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, passphrase, { mode: 0o600 });
+}
+
+export async function resolvePassphrase(
+  project: string,
+  mode: "local" | "deploy",
+): Promise<string> {
   const env = process.env["VYFT_PASSPHRASE"];
   if (env) return env;
 
+  const persisted = await readPersistedPassphrase(project);
+  if (persisted) return persisted;
+
+  if (mode === "local") {
+    const generated = crypto.randomBytes(32).toString("hex");
+    await persistPassphrase(project, generated);
+    log.info(`Generated passphrase saved to ${passphraseConfigPath(project)}`);
+    return generated;
+  }
+
   const value = await password({ message: "Enter passphrase:" });
   if (isCancel(value)) process.exit(1);
-  return value;
+
+  const save = await confirm({ message: "Save passphrase locally for future use?" });
+  if (!isCancel(save) && save) {
+    await persistPassphrase(project, value as string);
+    log.info(`Passphrase saved to ${passphraseConfigPath(project)}`);
+  }
+
+  return value as string;
 }
 
 export async function loadSalt(stateDir: string): Promise<Buffer> {

--- a/packages/vyft/src/runtime.ts
+++ b/packages/vyft/src/runtime.ts
@@ -31,6 +31,7 @@ function passphraseConfigPath(project: string): string {
 async function readPersistedPassphrase(project: string): Promise<string | null> {
   try {
     const data = await fs.readFile(passphraseConfigPath(project), "utf8");
+    // trim() strips trailing newlines from manually-edited files; whitespace-only content is treated as absent
     return data.trim() || null;
   } catch {
     return null;
@@ -45,7 +46,7 @@ async function persistPassphrase(project: string, passphrase: string): Promise<v
 
 export async function resolvePassphrase(
   project: string,
-  mode: "local" | "deploy",
+  mode: "local" | "deploy" | "read",
 ): Promise<string> {
   const env = process.env["VYFT_PASSPHRASE"];
   if (env) return env;
@@ -63,13 +64,16 @@ export async function resolvePassphrase(
   const value = await password({ message: "Enter passphrase:" });
   if (isCancel(value)) process.exit(1);
 
-  const save = await confirm({ message: "Save passphrase locally for future use?" });
-  if (!isCancel(save) && save) {
-    await persistPassphrase(project, value as string);
-    log.info(`Passphrase saved to ${passphraseConfigPath(project)}`);
+  if (mode === "deploy") {
+    const save = await confirm({ message: "Save passphrase locally for future use?" });
+    // Cancelling the save prompt is treated as "no" — passphrase is returned without saving
+    if (!isCancel(save) && save) {
+      await persistPassphrase(project, value);
+      log.info(`Passphrase saved to ${passphraseConfigPath(project)}`);
+    }
   }
 
-  return value as string;
+  return value;
 }
 
 export async function loadSalt(stateDir: string): Promise<Buffer> {


### PR DESCRIPTION
Implements passphrase persistence per #47, with explicit save confirmation for deploy commands.

**Resolution order:**
1. `VYFT_PASSPHRASE` env var
2. `~/.config/vyft/<project>/passphrase` file
3. Local: auto-generate and save
4. Deploy: prompt, then ask "Save locally for future use?"

Closes #47

Generated with [Claude Code](https://claude.ai/code)