### PR TITLE
refactor: move NODE_ENV from service constructor to runtime layer

### DIFF
--- a/packages/docker/src/client/container.ts
+++ b/packages/docker/src/client/container.ts
@@ -52,7 +52,8 @@ export function buildContainerConfig(
   image: string,
   ctx: { project: string; stage: string; networkName: string },
 ): ContainerConfig {
-  const env = Object.entries(input.env ?? {}).map(([k, v]) => `${k}=${v}`);
+  const baseEnv = { NODE_ENV: ctx.stage, ...input.env };
+  const env = Object.entries(baseEnv).map(([k, v]) => `${k}=${v}`);
 
   const labels: Record<string, string> = {
     "com.docker.compose.project": ctx.project,

--- a/packages/runtime/src/constructors.ts
+++ b/packages/runtime/src/constructors.ts
@@ -85,7 +85,6 @@ export const service = resource<ServiceConfig, ServiceInput>(
   (id, config) => {
     const env: Record<string, string> = {
       PORT: String(config.port ?? 3000),
-      NODE_ENV: "production",
       ...config.env,
     };
 


### PR DESCRIPTION
Remove hardcoded NODE_ENV=production from the service constructor and inject it from ctx.stage in buildContainerConfig instead.

Closes #46

Generated with [Claude Code](https://claude.ai/code)