### PR TITLE
perf(e2e): parallel + prod build + fewer navs

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -51,4 +51,15 @@ export default defineConfig({
       },
     },
   },
+  preview: {
+    host: true,
+    port: 3000,
+    strictPort: true,
+    proxy: {
+      "/api": {
+        target: "http://localhost:8080",
+        changeOrigin: true,
+      },
+    },
+  },
 });

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -4,19 +4,19 @@ import { BACKEND_URL, BASIC_AUTH, WEB_URL } from "./config.ts";
 
 export default defineConfig({
   testDir: "./src/specs",
-  fullyParallel: false,
-  workers: 1,
+  fullyParallel: true,
+  workers: process.env.PW_WORKERS ? Number(process.env.PW_WORKERS) : undefined,
   timeout: 180_000,
   expect: { timeout: 10_000 },
   retries: 0,
   reporter: "list",
   webServer: [
     {
-      command: "pnpm exec nx dev web",
+      command: "pnpm exec nx build web && pnpm exec nx preview web",
       cwd: "..",
       url: WEB_URL,
       reuseExistingServer: true,
-      timeout: 120_000,
+      timeout: 300_000,
     },
     {
       command: "go run ./cmd/backend",

--- a/e2e/src/lib/project/actions.ts
+++ b/e2e/src/lib/project/actions.ts
@@ -26,8 +26,7 @@ export async function create(page: Page, input: CreateInput): Promise<ProjectHan
   await page.getByTestId("project-create-submit").click();
   await createResponse;
 
-  await page.goto("/");
-  await page.locator(`[data-testid="project-card"][data-slug="${input.slug}"]`).click();
+  await page.goto(`/projects/${input.slug}`);
   await expect(page).toHaveURL(new RegExp(`/projects/${input.slug}`));
 
   return { slug: input.slug, name, namespace: namespaceFor(input.slug), resources: {} };


### PR DESCRIPTION
## What

Three independent speedups to the Playwright e2e suite, each verified empirically (3 warm runs, `--workers=2`, all green).

### 1. Parallel execution
`fullyParallel: true` + auto workers (was `fullyParallel: false`, `workers: 1`). Tests are already isolated — each gets a unique `slug` → its own project namespace (`src/lib/fixtures.ts`), random registry names, per-test cleanup — so spec files run concurrently. Override with `PW_WORKERS=N` (e.g. `PW_WORKERS=1` for a serial baseline).

### 2. Serve the production build instead of the dev server
webServer now runs `nx build web && nx preview web` rather than `nx dev web`. The dev server JIT-compiles each route on first navigation, which dominated wall-clock (nav steps were ~40-50% of the nav-heavy test). Adds a `preview` block to `apps/web/vite.config.ts` so `/api` proxies to the backend — `vite preview` does not inherit `server`.

### 3. Cut redundant navigations in `project.create`
Replaced index reload + project-card click with a direct `goto('/projects/<slug>')`. The slug is known and the `201` confirms the project exists.

## Proof (warm servers, `--workers=2`, mean of 3, all green)

| | registry test | deploy test | whole-run wall |
|---|---|---|---|
| dev server + nav-fix | 4818ms | 6704ms | 9344ms |
| **prod build + nav-fix** | **3278ms (-32%)** | **5770ms (-14%)** | **7944ms (-15%)** |

Prod-bundle runs were also lower-variance (7896–7985ms vs 9072–9497ms).

Parallelism separately verified: serial baseline shows 0 overlapping test intervals; parallel shows tests on distinct workers with overlapping intervals.

## Notes
- Gains scale with test count — wall is currently `max(test) + fixed overhead` for 2 specs.
- Remaining floor is real-infra waits (deploy apply + pod-Running poll) and browser launch; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)