### PR TITLE
chore(security): pin Docker base images + helm by SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,12 +70,13 @@ jobs:
           go-version-file: apps/backend/go.mod
           cache-dependency-path: apps/backend/go.sum
 
-      - name: install kind + helm
+      - name: install kind
         run: |
           curl -sSLo /tmp/kind https://kind.sigs.k8s.io/dl/v0.25.0/kind-linux-amd64
           chmod +x /tmp/kind
           sudo mv /tmp/kind /usr/local/bin/kind
-          curl -sSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | sudo bash
+
+      - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
 
       - name: start kind cluster + observability
         run: bash cluster/up.sh

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-alpine AS web-build
+FROM node:24-alpine@sha256:21f403ab171f2dc89bad4dd69d7721bfd15f084ccb46cdd225f31f2bc59b5c9a AS web-build
 
 WORKDIR /src
 
@@ -8,7 +8,7 @@ COPY . .
 RUN pnpm install --frozen-lockfile
 RUN pnpm exec nx build web
 
-FROM golang:alpine AS build
+FROM golang:1.26-alpine@sha256:f1ddd9fe14fffc091dd98cb4bfa999f32c5fc77d2f2305ea9f0e2595c5437c14 AS build
 
 WORKDIR /src/apps/backend
 
@@ -20,7 +20,7 @@ COPY --from=web-build /src/apps/web/dist ./internal/web/dist
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o /out/backend ./cmd/backend
 
-FROM gcr.io/distroless/static-debian12:nonroot AS runtime
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:d093aa3e30dbadd3efe1310db061a14da60299baff8450a17fe0ccc514a16639 AS runtime
 
 COPY --from=build /out/backend /backend
 


### PR DESCRIPTION
## Summary
Fixes 4 open Scorecard `Pinned-Dependencies` alerts:
- `apps/backend/Dockerfile`: pin `node:24-alpine`, `golang:1.26-alpine`, `distroless/static-debian12:nonroot` by digest (closes #29, #30, #31). Also bumps `golang:alpine` floating tag to `1.26`.
- `.github/workflows/ci.yml`: replace `curl | bash` helm install with `azure/setup-helm@SHA` v5.0.0 (closes #32).

## Remaining open code-scanning alerts (Scorecard meta — not file-level)
- #33 Code-Review, #34 CII-Best-Practices, #35 Fuzzing, #36 SAST, #37 Vulnerabilities, #38 CI-Tests — repo-policy findings, not code fixes. Suggest dismissing or addressing via repo settings (badges, CodeQL, OSS-Fuzz, etc).

## Test plan
- [ ] CI green
- [ ] Docker build still succeeds with pinned digests